### PR TITLE
more efficient buffer expansion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,14 @@
 Package: serializer
 Type: Package
 Title: Expose the Serialization Interface
-Version: 0.1.6
+Version: 0.1.7
 Author: mikefc
 Maintainer: mikefc <mikefc@coolbutuseless.com>
 Description: Expose the Serialization interface internal to R.
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Suggests: 
     testthat,
     knitr,


### PR DESCRIPTION
Hi Mike, just a note to say thanks. Your commentary in this project really made it very straightforward to implement an interface in https://github.com/shikokuchuo/nanonext I have credited you in the readme, hope you are fine with this.

I would like to reciprocate with what I think is a fairly uncontroversial tweak in allocating large objects: we do this in one go rather than constantly re-allocating.

